### PR TITLE
Added Expose 80 to the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ COPY --from=build /app ./
 #ENV LC_ALL en_US.UTF-8
 #ENV LANG en_US.UTF-8
 
+EXPOSE 80/tcp
+
 ENTRYPOINT ["./IntelliCenterGateway"]


### PR DESCRIPTION
This is so other services can auto detect what port is being used. I use this with jwilder/nginx-proxy and jrcs/letsencrypt-nginx-proxy-companion to frontend my webservices and auto provide SSL certs.